### PR TITLE
fix EOF bug, change makefile to not compile headers

### DIFF
--- a/k0gram.y
+++ b/k0gram.y
@@ -3,7 +3,7 @@
     #include "lex.h"
     #include "tree.h"
 %}
-
+//%debug
 %union {
     struct tree *treeptr;
 }
@@ -156,7 +156,6 @@
 %left ADD SUB
 %left MULT DIV MOD
 %right INCR DECR
-
 %start program
 
 %%
@@ -180,14 +179,14 @@ declaration:
     ;
 
 propertyDeclaration:
-    variable variableDeclaration SEMICOLON {$$ = alctoken(2001, "propDecEmpty", 3, $1, $2, $3);}
-    | variable variableDeclaration assignment SEMICOLON {$$ = alctoken(2002, "propDecAssign", 4, $1, $2, $3, $4);}
-    | variable reciverType variableDeclaration SEMICOLON {$$ = alctoken(2003, "propDecReciver", 4, $1, $2, $3, $4);}
-    | variable reciverType variableDeclaration assignment SEMICOLON {$$ = alctoken(2004, "propDecReciverAssign", 5, $1, $2, $3, $4, $5);}
-    | variable typeParameters variableDeclaration SEMICOLON {$$ = alctoken(2005, "propDecTypeParams", 4, $1, $2, $3, $4);}
-    | variable typeParameters variableDeclaration assignment SEMICOLON {$$ = alctoken(2006, "propDecTypeParamsAssign", 5, $1, $2, $3, $4, $5);}
-    | variable typeParameters reciverType variableDeclaration SEMICOLON {$$ = alctoken(2007, "propDecTypeParamsReciver", 5, $1, $2, $3, $4, $5);}
-    | variable typeParameters reciverType variableDeclaration assignment SEMICOLON {$$ = alctoken(2008, "propDecAll", 6, $1, $2, $3, $4, $5, $6);}
+    variable variableDeclaration  {$$ = alctoken(2001, "propDecEmpty", 3, $1, $2);}
+    | variable variableDeclaration assignment  {$$ = alctoken(2002, "propDecAssign", 4, $1, $2, $3);}
+    | variable reciverType variableDeclaration  {$$ = alctoken(2003, "propDecReciver", 4, $1, $2, $3);}
+    | variable reciverType variableDeclaration assignment  {$$ = alctoken(2004, "propDecReciverAssign", 5, $1, $2, $3, $4);}
+    | variable typeParameters variableDeclaration  {$$ = alctoken(2005, "propDecTypeParams", 4, $1, $2, $3);}
+    | variable typeParameters variableDeclaration assignment  {$$ = alctoken(2006, "propDecTypeParamsAssign", 5, $1, $2, $3, $4);}
+    | variable typeParameters reciverType variableDeclaration  {$$ = alctoken(2007, "propDecTypeParamsReciver", 5, $1, $2, $3, $4);}
+    | variable typeParameters reciverType variableDeclaration assignment  {$$ = alctoken(2008, "propDecAll", 6, $1, $2, $3, $4, $5);}
 
 variable:
     VAL {$$ = $1;}

--- a/kotlex.l
+++ b/kotlex.l
@@ -243,6 +243,6 @@ directive               "# "{integer_literal}" "\"{identifier}\"
 {character_error}								{ printf("File: %s Line:%d Character Literals cannot have more than one character:\t%s\n", filename, rows, yytext); exit(1); }
 .												{ printf("File: %s Line:%d Unknown error\n", filename, rows); exit(1); }
 
-<<EOF>>     									{ return token(EOF_K); }
+<<EOF>>     									{ return 0; }
 
 %%

--- a/main.c
+++ b/main.c
@@ -8,7 +8,7 @@
 
 char *filename;
 char temp[100];
-
+//extern int yydebug;
 void openFile(char *name);
 
 int main(int argc, char *argv[])
@@ -23,6 +23,7 @@ int main(int argc, char *argv[])
     //checks that the file name is legal and opens the file
     openFile(argv[1]);
 
+    //yydebug = 1;
     yyparse();
 
 }


### PR DESCRIPTION
Modified makefile

- $^ includes all prereqs named, didn't throw errors before until definitions were double built into the object files

Fix EOF syntax error

- Bison expects "nothing" at the EOF from the lexer (return 0) while we were passing a token EOF. Even if we placed a terminal  EOF_K token at the program level, Bison has the extra EOF token and doesn't know how to reduce.